### PR TITLE
Align text/icon when paperTab has a link

### DIFF
--- a/lib/paper-elements/PaperTab/PaperTab.tpl.jade
+++ b/lib/paper-elements/PaperTab/PaperTab.tpl.jade
@@ -5,7 +5,7 @@ paper-tab(class=className
   +PaperRipple(className="paper-tab" id="ink")
   div(class="tab-content  paper-tab" flex-auto center-center horizontal layout)
     if link
-      a(href=link)
+      a(href=link layout horizontal center)
         +Template.contentBlock
     else
       +Template.contentBlock


### PR DESCRIPTION
@pixelass without this the icon and the text are misaligned when the tab has a link.
