### PR TITLE
Fixed reactivity issues in PaperTabs and IronSelector

### DIFF
--- a/lib/iron-elements/IronSelector/IronSelector.es6
+++ b/lib/iron-elements/IronSelector/IronSelector.es6
@@ -3,15 +3,25 @@ Material = Material || {}
 
 Material.IronSelector = IronSelector = class IronSelector extends BlazeComponent {
 
+  constructor() {
+    super();
+    this.updateSelectedIndex = this.updateSelectedIndex.bind(this);
+    this.updateSelection = this.updateSelection.bind(this);
+  }
+
   /**
    * set defaults
    */
   onCreated () {
-    this.selected = new ReactiveVar(this.data().selected || 0);
+    this.selected = new ReactiveVar(0);
     //console.log(this.data().onUpdate)
     //this.updateParent = this.data().update;
+    this.autorun(this.updateSelectedIndex);
  }
 
+  updateSelectedIndex () {
+    this.selected.set(this.data().selected || 0);
+  }
 
 
   handleClick (e) {
@@ -30,9 +40,10 @@ Material.IronSelector = IronSelector = class IronSelector extends BlazeComponent
   }
 
   updateSelection () {
+    let selected = parseInt(this.selected.get(),10);
     var $elements = this.findAll('>*>*');
     $elements.forEach((item, index)=>{
-      let isSelected = index === parseInt(this.selected.get(),10);
+      let isSelected = index === selected;
       item.classList.toggle('iron-selected', isSelected);
     });
   }
@@ -42,7 +53,7 @@ Material.IronSelector = IronSelector = class IronSelector extends BlazeComponent
    */
   onRendered () {
     this.selector = this.componentChildrenWith('selected');
-    this.updateSelection();
+    this.autorun(this.updateSelection);
 
   }
 

--- a/lib/paper-elements/PaperTabs/PaperTabs.es6
+++ b/lib/paper-elements/PaperTabs/PaperTabs.es6
@@ -15,7 +15,6 @@ class PaperTabs extends BlazeComponent {
    */
   onRendered() {
     this.selector = this.componentChildrenWith('selected')[0];
-    this.selected = this.selector.selected.get();
     this.selectorElement = this.selector.firstNode();
     this.selectorElement.setAttribute('flex', '');
     this.selectorElement.setAttribute('horizontal', '');
@@ -27,15 +26,18 @@ class PaperTabs extends BlazeComponent {
 
   }
 
+  getSelected() {
+    return this.selector.selected.get();
+  }
+
   handleClick() {
-    this.selected = this.selector.selected.get();
     this.updatePosition();
     this.updateScrollable();
   }
 
   updateScrollable(){
     let length = this.findAll('paper-tab').length;
-    let current = this.selected;
+    let current = this.getSelected();
     // console.log(length, current)
 
     if (this.scrollable && current < length - 1) {
@@ -54,7 +56,7 @@ class PaperTabs extends BlazeComponent {
 
   updatePosition(){
     let tabs = this.tabs.length;
-    let selectedTab = this.find('paper-tab:nth-child('+ (parseInt(this.selected,10)  + 1) +')');
+    let selectedTab = this.find('paper-tab:nth-child('+ (parseInt(this.getSelected(),10)  + 1) +')');
     let scale = selectedTab.offsetWidth/(this.selectorElement.offsetWidth);
     this.style.set('transform:translate3d('+ selectedTab.offsetLeft +'px,0,0) scaleX('+ scale + ')');
   }


### PR DESCRIPTION
@pixelass this fixes reactivity issues with PaperTabs, otherwise now it doesn't change the selection when the `selected` attribute which is passed to PaperTabs changes.
